### PR TITLE
Switch from GCP promotion cloud function to cirrus jfrog promotion

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,7 @@ promote_task:
     memory: 500M
   env:
     ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
+    GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
     #artifacts that will have downloadable links in burgr
     ARTIFACTS: "org.sonarsource.roslynsdk:sonar-roslyn-sdk-template-plugin:jar" 
   maven_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,10 +53,7 @@ promote_task:
     cpu: 0.5
     memory: 500M
   env:
-    #promotion cloud function
-    GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-    PROMOTE_URL: VAULT[development/kv/data/promote data.url]
-    GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
+    ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     #artifacts that will have downloadable links in burgr
     ARTIFACTS: "org.sonarsource.roslynsdk:sonar-roslyn-sdk-template-plugin:jar" 
   maven_cache:


### PR DESCRIPTION
Ref: https://trello.com/c/aXyMOS0H/1104-infra-use-cirrusjfrogpromote-for-t-sql-pl-sql-vb-and-sdk