### PR TITLE
Bump version to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.sonarsource.roslynsdk</groupId>
   <artifactId>sonar-roslyn-sdk-template-plugin</artifactId>
-  <version>1.2</version>
+  <version>1.3-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube Roslyn SDK Template Plugin</name>


### PR DESCRIPTION
The `-SNAPSHOT` suffix is the correct thing to do. It got replaced in this PR with 1.3.0.1132

After a proper bump in #17, the snapshot got lost in #21 that looks suspicious