### PR TITLE
Add Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+---
+name: sonar-release
+# This workflow is triggered when publishing a new github release
+# yamllint disable-line rule:truthy
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    permissions:
+      id-token: write
+      contents: write
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5


### PR DESCRIPTION
This should get us promotion of the jar in Repox during the release.

There's no way to test if it will actually work or not - I'm worried if this repo has access to all necessary tokens. It might have, as the build works.