### PR TITLE
NET-3806 Set explicit check-sca project key metadata

### DIFF
--- a/.github/repo-metadata.yaml
+++ b/.github/repo-metadata.yaml
@@ -1,0 +1,2 @@
+check-sca:
+  project-key: SonarSource_dotnet-tooling


### PR DESCRIPTION
Part of 
<!--
  Only for standalone PRs without Jira issue in the PR title:
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent
-->

----
## Summary by Gitar

- **Metadata configuration:**
  - Added `repo-metadata.yaml` to define the `check-sca` project key as `SonarSource_dotnet-tooling`.

<sub>This will update automatically on new commits.</sub>