### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/quality-dotnet-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Repository configuration:**
  - Updated `.github/CODEOWNERS` to assign ownership to `@SonarSource/code-quality-core-languages-parsers-squad` instead of `@SonarSource/quality-dotnet-squad`.

<sub>This will update automatically on new commits.</sub>