### PR TITLE
CLP-212: Migrate scanner test fixtures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <artifactsToPublish>org.sonarsource.roslynsdk:sonar-roslyn-sdk-template-plugin:jar</artifactsToPublish>
     <!-- SQ vs. API version table: https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#sonarqube -->
     <sonar.plugin.api.version>13.8.0.4399</sonar.plugin.api.version>
+    <sonar.scanner.version>13.4.1.4007</sonar.scanner.version>
     <maven.compiler.release>17</maven.compiler.release>
     <license.title>SonarQube Roslyn SDK Template Plugin</license.title>
     <license.name>GNU LGPL v3</license.name>
@@ -55,10 +56,17 @@
       <version>${sonar.plugin.api.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- Required by RoslynSdkRulesDefinitionTest for LogTesterJUnit5. -->
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <version>${sonar.plugin.api.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
+      <version>${sonar.scanner.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -91,18 +99,6 @@
       <artifactId>mockito-core</artifactId>
       <version>5.23.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-      <version>26.7.0.124771</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/src/test/java/org/sonar/plugins/roslynsdk/RoslynSdkGeneratedPluginTest.java
+++ b/src/test/java/org/sonar/plugins/roslynsdk/RoslynSdkGeneratedPluginTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.roslynsdk;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +28,6 @@ import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.config.PropertyDefinition;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -37,7 +37,7 @@ public class RoslynSdkGeneratedPluginTest {
   @Test
   public void getExtensions() {
     RoslynSdkGeneratedPlugin plugin = new RoslynSdkGeneratedPlugin();
-    Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(Version.create(9, 9), SonarQubeSide.SCANNER,
+    Plugin.Context context = new Plugin.Context(TestSonarRuntime.forSonarQube(Version.create(9, 9), SonarQubeSide.SCANNER,
       SonarEdition.COMMUNITY));
     plugin.define(context);
 

--- a/src/test/java/org/sonar/plugins/roslynsdk/RoslynSdkRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/roslynsdk/RoslynSdkRulesDefinitionTest.java
@@ -22,7 +22,6 @@ package org.sonar.plugins.roslynsdk;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonar.api.rules.RuleType;
@@ -50,11 +49,7 @@ public class RoslynSdkRulesDefinitionTest {
     rulesDefinedWithSqaleXml(null);
   }
 
-  private void rulesDefinedWithSqaleXml(@Nullable String sqaleXmlResourcePath) {
-    rulesDefinedWithSqaleXml(sqaleXmlResourcePath, false);
-  }
-
-  private void rulesDefinedWithSqaleXml(@Nullable String sqaleXmlResourcePath, boolean withBOM) {
+  private void rulesDefinedWithSqaleXml(String sqaleXmlResourcePath) {
     Context context = new Context();
     assertThat(context.repositories()).isEmpty();
 


### PR DESCRIPTION
## Summary

- replace the SonarQube `sonar-plugin-api-impl` test dependency with scanner-engine `sensor-test-fixtures` 13.4.1.4007
- replace `SonarRuntimeImpl` with `TestSonarRuntime`
- remove now-unneeded `Nullable` annotations that were supplied transitively by the removed implementation artifact
- retain `sonar-plugin-api-test-fixtures` because `RoslynSdkRulesDefinitionTest` uses `LogTesterJUnit5`

## Dependency changes

Before: tests directly depended on `org.sonarsource.sonarqube:sonar-plugin-api-impl:26.7.0.124771` for `SonarRuntimeImpl` and incidental transitive classes.

After: tests directly depend on `org.sonarsource.scanner.engine:sensor-test-fixtures:13.4.1.4007` for `TestSonarRuntime`. No scanner implementation artifact is needed because these tests do not import concrete `org.sonar.scanner.plugin.api.impl` types.

## Validation

- `mvn verify` — 11 tests pass and the plugin packages successfully
- `mvn dependency:tree -Dscope=test -Dincludes=org.sonarsource.sonarqube:sonar-plugin-api-impl` — no matches
- `git diff --check`

Related to [CLP-212](https://sonarsource.atlassian.net/browse/CLP-212).


[CLP-212]: https://sonarsource.atlassian.net/browse/CLP-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ